### PR TITLE
feat: #8 선택한 게시글 수정 기능 구현

### DIFF
--- a/src/main/java/com/sparta/board/controller/BoardController.java
+++ b/src/main/java/com/sparta/board/controller/BoardController.java
@@ -29,4 +29,9 @@ public class BoardController {
         return boardService.getPost(id);
     }
 
+    @PutMapping("/api/post/{id}")
+    public BoardResponseDto updatePost(@PathVariable Long id, @RequestBody BoardRequestsDto requestsDto) throws Exception {
+        return boardService.updatePost(id, requestsDto);
+    }
+
 }

--- a/src/main/java/com/sparta/board/entity/Board.java
+++ b/src/main/java/com/sparta/board/entity/Board.java
@@ -32,4 +32,11 @@ public class Board extends Timestamped {
         this.author = requestsDto.getAuthor();
         this.password = requestsDto.getPassword();
     }
+
+    public void update(BoardRequestsDto requestsDto) {
+        this.title = requestsDto.getTitle();
+        this.contents = requestsDto.getContents();
+        this.author = requestsDto.getAuthor();
+        this.password = requestsDto.getPassword();
+    }
 }

--- a/src/main/java/com/sparta/board/service/BoardService.java
+++ b/src/main/java/com/sparta/board/service/BoardService.java
@@ -41,4 +41,16 @@ public class BoardService {
         );
         return new BoardResponseDto(board.getId(), board.getTitle(), board.getContents(), board.getAuthor(), board.getCreatedAt(), board.getModifiedAt());
     }
+
+    @Transactional
+    public BoardResponseDto updatePost(Long id, BoardRequestsDto requestsDto) throws Exception {
+        Board board = boardRepository.findById(id).orElseThrow(
+                () -> new IllegalArgumentException("아이디가 존재하지 않습니다.")
+        );
+        if (!requestsDto.getPassword().equals(board.getPassword()))
+            throw new Exception("비밀번호가 일치하지 않습니다.");
+
+        board.update(requestsDto);
+        return new BoardResponseDto(board.getId(), board.getTitle(), board.getContents(), board.getAuthor(), board.getCreatedAt(), board.getModifiedAt());
+    }
 }


### PR DESCRIPTION
- id와 변경할 내용이 담긴 requestsDto를 보내면, 수정된 내용의 responseDto를 리턴하는 `updatePost` 작성
- 일치하는 아이디가 없을 경우 -> "아이디가 존재하지 않습니다."
- 비밀번호가 일치하지 않는 경우 -> "비밀번호가 일치하지 않습니다." exception 처리했다.
- `Board` 엔티티에 `update` 함수 구현

closes #8