### PR TITLE
feat: #9 선택한 게시글 삭제 기능 구현

### DIFF
--- a/src/main/java/com/sparta/board/controller/BoardController.java
+++ b/src/main/java/com/sparta/board/controller/BoardController.java
@@ -2,6 +2,7 @@ package com.sparta.board.controller;
 
 import com.sparta.board.dto.BoardRequestsDto;
 import com.sparta.board.dto.BoardResponseDto;
+import com.sparta.board.dto.SuccessResponseDto;
 import com.sparta.board.service.BoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -32,6 +33,11 @@ public class BoardController {
     @PutMapping("/api/post/{id}")
     public BoardResponseDto updatePost(@PathVariable Long id, @RequestBody BoardRequestsDto requestsDto) throws Exception {
         return boardService.updatePost(id, requestsDto);
+    }
+
+    @DeleteMapping("/api/post/{id}")
+    public SuccessResponseDto deletePost(@PathVariable Long id, @RequestBody BoardRequestsDto requestsDto) throws Exception {
+        return boardService.deletePost(id, requestsDto);
     }
 
 }

--- a/src/main/java/com/sparta/board/dto/SuccessResponseDto.java
+++ b/src/main/java/com/sparta/board/dto/SuccessResponseDto.java
@@ -1,0 +1,12 @@
+package com.sparta.board.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SuccessResponseDto {
+    private boolean success;
+
+    public SuccessResponseDto(boolean success) {
+        this.success = success;
+    }
+}

--- a/src/main/java/com/sparta/board/service/BoardService.java
+++ b/src/main/java/com/sparta/board/service/BoardService.java
@@ -2,6 +2,7 @@ package com.sparta.board.service;
 
 import com.sparta.board.dto.BoardRequestsDto;
 import com.sparta.board.dto.BoardResponseDto;
+import com.sparta.board.dto.SuccessResponseDto;
 import com.sparta.board.entity.Board;
 import com.sparta.board.repository.BoardRepository;
 import lombok.RequiredArgsConstructor;
@@ -52,5 +53,18 @@ public class BoardService {
 
         board.update(requestsDto);
         return new BoardResponseDto(board.getId(), board.getTitle(), board.getContents(), board.getAuthor(), board.getCreatedAt(), board.getModifiedAt());
+    }
+
+    @Transactional
+    public SuccessResponseDto deletePost(Long id, BoardRequestsDto requestsDto) throws Exception {
+        Board board = boardRepository.findById(id).orElseThrow(
+                () -> new IllegalArgumentException("아이디가 존재하지 않습니다.")
+        );
+
+        if (!requestsDto.getPassword().equals(board.getPassword()))
+            throw new Exception("비밀번호가 일치하지 않습니다.");
+
+        boardRepository.deleteById(id);
+        return new SuccessResponseDto(true);
     }
 }


### PR DESCRIPTION
- id와 패스워드가 담긴 requestsDto를 보내면, 삭제 성공되었는지 `SuccessResponseDto` 리턴
- 일치하는 아이디가 없을 경우 -> "아이디가 존재하지 않습니다."
- 비밀번호가 일치하지 않는 경우 -> "비밀번호가 일치하지 않습니다." exception 처리했다.
- 성공여부 리턴을 위해 `SuccessResponseDto`를 구현했다.

closes #9