### PR TITLE
refactor: #18 responseDto 생성자 수정

### DIFF
--- a/src/main/java/com/sparta/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/sparta/board/dto/BoardResponseDto.java
@@ -2,10 +2,12 @@ package com.sparta.board.dto;
 
 import com.sparta.board.entity.Board;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor
 public class BoardResponseDto {
     private Long id;
     private String title;
@@ -14,23 +16,13 @@ public class BoardResponseDto {
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
-    public BoardResponseDto(Long id, String title, String contents, String author, LocalDateTime createdAt, LocalDateTime modifiedAt) {
-        this.id = id;
-        this.title = title;
-        this.contents = contents;
-        this.author = author;
-        this.createdAt = createdAt;
-        this.modifiedAt = modifiedAt;
+    public BoardResponseDto(Board entity) {
+        this.id = entity.getId();
+        this.title = entity.getTitle();
+        this.contents = entity.getContents();
+        this.author = entity.getAuthor();
+        this.createdAt = entity.getCreatedAt();
+        this.modifiedAt = entity.getModifiedAt();
     }
 
-    public static BoardResponseDto from(Board entity) {
-        return new BoardResponseDto(
-                entity.getId(),
-                entity.getTitle(),
-                entity.getContents(),
-                entity.getAuthor(),
-                entity.getCreatedAt(),
-                entity.getModifiedAt()
-        );
-    }
 }

--- a/src/main/java/com/sparta/board/service/BoardService.java
+++ b/src/main/java/com/sparta/board/service/BoardService.java
@@ -19,19 +19,19 @@ public class BoardService {
 
     @Transactional(readOnly = true)
     public List<BoardResponseDto> getPosts() {
-        return boardRepository.findAllByOrderByModifiedAtDesc().stream().map(BoardResponseDto::from).toList();
+        return boardRepository.findAllByOrderByModifiedAtDesc().stream().map(BoardResponseDto::new).toList();
     }
 
     @Transactional
     public BoardResponseDto createPost(BoardRequestsDto requestsDto) {
         Board board = new Board(requestsDto);
         boardRepository.save(board);
-        return BoardResponseDto.from(board);
+        return new BoardResponseDto(board);
     }
 
     @Transactional
     public BoardResponseDto getPost(Long id) {
-        return boardRepository.findById(id).map(BoardResponseDto::from).orElseThrow(
+        return boardRepository.findById(id).map(BoardResponseDto::new).orElseThrow(
                 () -> new IllegalArgumentException("아이디가 존재하지 않습니다.")
         );
     }
@@ -45,7 +45,7 @@ public class BoardService {
             throw new Exception("비밀번호가 일치하지 않습니다.");
 
         board.update(requestsDto);
-        return BoardResponseDto.from(board);
+        return new BoardResponseDto(board);
     }
 
     @Transactional


### PR DESCRIPTION
- 원래 static 메서드를 만들어 엔티티를 dto로 바꾸도록 했었다.
- static 메서드 대신, 생성자에서 entity를 받아서 dto로 생성할 수 있게 수정했다.
- `Board` 클래스에서 `requestsDto`를 받아서 `Board` 엔티티를 생성하는 부분을 참고했다.

closes #18