### PR TITLE
feat: #26 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/board/controller/UserController.java
+++ b/src/main/java/com/sparta/board/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.sparta.board.controller;
+
+import com.sparta.board.dto.SignupRequestDto;
+import com.sparta.board.dto.SuccessResponseDto;
+import com.sparta.board.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<SuccessResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto, BindingResult bindingResult) {
+        return userService.signup(requestDto, bindingResult);
+    }
+}

--- a/src/main/java/com/sparta/board/dto/SignupRequestDto.java
+++ b/src/main/java/com/sparta/board/dto/SignupRequestDto.java
@@ -1,0 +1,20 @@
+package com.sparta.board.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import javax.validation.constraints.Pattern;
+
+@Getter
+@RequiredArgsConstructor
+public class SignupRequestDto {
+
+    // 아이디 유효성 검사
+    @Pattern(regexp = "^[a-z0-9]{4,10}$", message = "아이디는 4~10자리 영문 소문자(a~z),숫자(0~9)를 사용하세요!")
+    private String username;
+
+    // 비밀번호 유효성 검사
+    @Pattern(regexp = "^[a-zA-Z0-9]{8,15}$", message = "비밀번호는 8~15자리 영문 대소문자(a~z, A~Z), 숫자(0~9)를 사용하세요!")
+    private String password;
+
+}

--- a/src/main/java/com/sparta/board/dto/SuccessResponseDto.java
+++ b/src/main/java/com/sparta/board/dto/SuccessResponseDto.java
@@ -1,12 +1,15 @@
 package com.sparta.board.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Getter
 public class SuccessResponseDto {
-    private boolean success;
-
-    public SuccessResponseDto(boolean success) {
-        this.success = success;
-    }
+    private String msg;
+    private int statusCode;
 }

--- a/src/main/java/com/sparta/board/entity/User.java
+++ b/src/main/java/com/sparta/board/entity/User.java
@@ -1,14 +1,15 @@
 package com.sparta.board.entity;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 @Entity(name = "users")
 public class User {
 

--- a/src/main/java/com/sparta/board/repository/UserRepository.java
+++ b/src/main/java/com/sparta/board/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.board.repository;
+
+import com.sparta.board.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    // 중복 회원가입 방지를 위해 같은 이름의 username 있는지 찾는다.
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/sparta/board/service/UserService.java
+++ b/src/main/java/com/sparta/board/service/UserService.java
@@ -1,0 +1,56 @@
+package com.sparta.board.service;
+
+import com.sparta.board.dto.SignupRequestDto;
+import com.sparta.board.dto.SuccessResponseDto;
+import com.sparta.board.entity.User;
+import com.sparta.board.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.BindingResult;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ResponseEntity<SuccessResponseDto> signup(SignupRequestDto requestDto, BindingResult bindingResult) {
+        String username = requestDto.getUsername();
+        String password = requestDto.getPassword();
+
+        // 입력한 username, password 유효성 검사 통과 못한 경우
+        if (bindingResult.hasErrors()) {
+            return ResponseEntity.badRequest().body(SuccessResponseDto.builder()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .msg(bindingResult.getAllErrors().get(0).getDefaultMessage())
+                    .build());
+        }
+
+        // 회원 중복 확인
+        Optional<User> found = userRepository.findByUsername(username);
+        if (found.isPresent()) {
+            return ResponseEntity.badRequest().body(SuccessResponseDto.builder()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .msg("중복된 사용자가 존재합니다.")
+                    .build());
+        }
+
+        // 입력한 username, password 로 user 객체 만들어 repository 에 저장
+        userRepository.save(User.builder()
+                .username(username)
+                .password(password)
+                .build());
+
+        return ResponseEntity.ok(SuccessResponseDto.builder()
+                .statusCode(HttpStatus.OK.value())
+                .msg("회원가입 성공")
+                .build());
+
+    }
+}


### PR DESCRIPTION
- 아이디, 비밀번호 유효성 검사를 위해 validation 의존성을 추가했다.
- 컨트롤러에서 requestDto 를 받을 때 `@Valid`를 사용한다. 유효성 검사에서 에러가 발생했을 때 처리하기 위해 `BindingResult`도 파라미터로 받는다.
- 유효성 검사를 위해 `SignupRequestDto`에서 `@Pattern` 사용했다.
- 기존에 사용하던 `SuccessResponseDto`를 수정해서 `ResponseEntity`의 body 에 넣어 반환한다.
- entity 와 dto 는 생성자 대신 Builder 로 객체 만들기 위해 `@Builder`를 추가했다.

closes #26