### PR TITLE
feat: #27 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/board/controller/UserController.java
+++ b/src/main/java/com/sparta/board/controller/UserController.java
@@ -1,7 +1,7 @@
 package com.sparta.board.controller;
 
-import com.sparta.board.dto.SignupRequestDto;
 import com.sparta.board.dto.SuccessResponseDto;
+import com.sparta.board.dto.UserRequestDto;
 import com.sparta.board.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +21,12 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public ResponseEntity<SuccessResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto, BindingResult bindingResult) {
+    public ResponseEntity<SuccessResponseDto> signup(@Valid @RequestBody UserRequestDto requestDto, BindingResult bindingResult) {
         return userService.signup(requestDto, bindingResult);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<SuccessResponseDto> login(@RequestBody UserRequestDto requestDto) {
+        return userService.login(requestDto);
     }
 }

--- a/src/main/java/com/sparta/board/dto/UserRequestDto.java
+++ b/src/main/java/com/sparta/board/dto/UserRequestDto.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.Pattern;
 
 @Getter
 @RequiredArgsConstructor
-public class SignupRequestDto {
+public class UserRequestDto {
 
     // 아이디 유효성 검사
     @Pattern(regexp = "^[a-z0-9]{4,10}$", message = "아이디는 4~10자리 영문 소문자(a~z),숫자(0~9)를 사용하세요!")

--- a/src/main/java/com/sparta/board/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/board/jwt/JwtUtil.java
@@ -1,0 +1,84 @@
+package com.sparta.board.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String AUTHORIZATION_KEY = "auth";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final long TOKEN_TIME = 60 * 60 * 1000L;
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+    private Key key;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    // header 토큰을 가져오기
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    // 토큰 생성
+    public String createToken(String username) {
+        Date date = new Date();
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(username)
+                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                        .setIssuedAt(date)
+                        .signWith(key, signatureAlgorithm)
+                        .compact();
+    }
+
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT token, 만료된 JWT token 입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+        }
+        return false;
+    }
+
+    // 토큰에서 사용자 정보 가져오기
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+
+}
+

--- a/src/main/java/com/sparta/board/service/UserService.java
+++ b/src/main/java/com/sparta/board/service/UserService.java
@@ -1,10 +1,12 @@
 package com.sparta.board.service;
 
-import com.sparta.board.dto.SignupRequestDto;
 import com.sparta.board.dto.SuccessResponseDto;
+import com.sparta.board.dto.UserRequestDto;
 import com.sparta.board.entity.User;
+import com.sparta.board.jwt.JwtUtil;
 import com.sparta.board.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -18,9 +20,10 @@ import java.util.Optional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
 
     @Transactional
-    public ResponseEntity<SuccessResponseDto> signup(SignupRequestDto requestDto, BindingResult bindingResult) {
+    public ResponseEntity<SuccessResponseDto> signup(UserRequestDto requestDto, BindingResult bindingResult) {
         String username = requestDto.getUsername();
         String password = requestDto.getPassword();
 
@@ -51,6 +54,43 @@ public class UserService {
                 .statusCode(HttpStatus.OK.value())
                 .msg("회원가입 성공")
                 .build());
+
+    }
+
+    @Transactional(readOnly = true)
+    public ResponseEntity<SuccessResponseDto> login(UserRequestDto requestDto) {
+        String username = requestDto.getUsername();
+        String password = requestDto.getPassword();
+
+        // 사용자 확인
+        Optional<User> user = userRepository.findByUsername(username);
+        if (user.isEmpty()) {
+            return ResponseEntity.badRequest()  // status : badRequest
+                    .body(SuccessResponseDto.builder() // body : SuccessResponseDto -> statusCode, msg
+                            .statusCode(HttpStatus.BAD_REQUEST.value())
+                            .msg("등록된 사용자가 없습니다.")
+                            .build());
+        }
+
+        // 비밀번호 확인
+        if(!user.get().getPassword().equals(password)){
+            return ResponseEntity.badRequest()
+                    .body(SuccessResponseDto.builder()
+                            .statusCode(HttpStatus.BAD_REQUEST.value())
+                            .msg("비밀번호가 일치하지 않습니다.")
+                            .build());
+        }
+
+        // header 에 들어갈 JWT 세팅
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(JwtUtil.AUTHORIZATION_HEADER, jwtUtil.createToken(user.get().getUsername()));
+
+        return ResponseEntity.ok()  // status -> OK
+                .headers(headers)   // headers -> JWT
+                .body(SuccessResponseDto.builder() // body -> SuccessResponseDto -> statusCode, msg
+                        .statusCode(HttpStatus.OK.value())
+                        .msg("로그인 성공")
+                        .build());
 
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,4 +4,9 @@ spring.datasource.username=sa
 spring.datasource.password=
 
 spring.thymeleaf.cache=false
-spring.jpa.properties.hibrenate.format_sql=true
+
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+jwt.secret.key=7ZWt7ZW0OTntmZTsnbTtjIXtlZzqta3snYTrhIjrqLjshLjqs4TroZzrgpjslYTqsIDsnpDtm4zrpa3tlZzqsJzrsJzsnpDrpbzrp4zrk6TslrTqsIDsnpA=
+


### PR DESCRIPTION
- JWT 토큰 생성을 위해 property 에 jwt secret key 를 추가하고, 관련 디펜던시를 추가했다.
- JWT 토큰 생성을 위한 `JwtUtil`을 만들었다.
- signup 과 login 모두 동일한 requestDto 를 사용하면 되어서 기존 `SignupRequestDto`를 `UserRequestDto`로 바꾸었다.
- 사용자 확인, 비밀번호 확인이 통과 못 할 경우, ResponseEntity에 statusCode와 메시지를 담아 반환했다.

* statusCode 관련 현재는 200 아니면 400으로 처리했는데 어떤 상황에 어떤 코드를 써야할지 고민해봐야 한다.

closes #27