### PR TITLE
feat: #29 게시글 조회 관련 responseDto 수정

### DIFF
--- a/src/main/java/com/sparta/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/sparta/board/dto/BoardResponseDto.java
@@ -12,7 +12,7 @@ public class BoardResponseDto {
     private Long id;
     private String title;
     private String contents;
-    private String author;
+    private String username;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
@@ -20,7 +20,7 @@ public class BoardResponseDto {
         this.id = entity.getId();
         this.title = entity.getTitle();
         this.contents = entity.getContents();
-        this.author = entity.getAuthor();
+        this.username = entity.getUser().getUsername();
         this.createdAt = entity.getCreatedAt();
         this.modifiedAt = entity.getModifiedAt();
     }


### PR DESCRIPTION
게시글 조회 시, 작성자명 필드 값을 `username`으로 변경하였다.
`Board`에서 기존 username, password 가 `User` 객체로 바뀌어서 `username`을 불러올 때 `getUser().getUsername()`으로 사용했다.

closes #29