### PR TITLE
feat: #31 게시글 수정 기능 구현

### DIFF
--- a/src/main/java/com/sparta/board/controller/BoardController.java
+++ b/src/main/java/com/sparta/board/controller/BoardController.java
@@ -33,9 +33,10 @@ public class BoardController {
         return boardService.getPost(id);
     }
 
+    // 선택된 게시글 수정
     @PutMapping("/api/post/{id}")
-    public BoardResponseDto updatePost(@PathVariable Long id, @RequestBody BoardRequestsDto requestsDto) throws Exception {
-        return boardService.updatePost(id, requestsDto);
+    public BoardResponseDto updatePost(@PathVariable Long id, @RequestBody BoardRequestsDto requestsDto, HttpServletRequest request) {
+        return boardService.updatePost(id, requestsDto, request);
     }
 
 //    @DeleteMapping("/api/post/{id}")

--- a/src/main/java/com/sparta/board/entity/Board.java
+++ b/src/main/java/com/sparta/board/entity/Board.java
@@ -28,10 +28,9 @@ public class Board extends Timestamped {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    public void update(BoardRequestsDto requestsDto) {
+    public void update(BoardRequestsDto requestsDto, User user) {
         this.title = requestsDto.getTitle();
         this.contents = requestsDto.getContents();
-//        this.author = requestsDto.getAuthor();
-//        this.password = requestsDto.getPassword();
+        this.user = user;
     }
 }

--- a/src/main/java/com/sparta/board/repository/BoardRepository.java
+++ b/src/main/java/com/sparta/board/repository/BoardRepository.java
@@ -1,12 +1,15 @@
 package com.sparta.board.repository;
 
 import com.sparta.board.entity.Board;
+import com.sparta.board.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
     List<Board> findAllByOrderByModifiedAtDesc();
+    Optional<Board> findByIdAndUser(Long id, User user);
 }


### PR DESCRIPTION
- 토큰 값을 확인하기 위해 `updatePost`에서 `HttpServletRequest`를 파라미터에 추가했다.
- 선택한 게시글의 id와 토큰에서 가져온 사용자 정보가 일치하는 게시물이 있는지 확인하기 위해 `findByIdAndUser` 메서드를 repository 에 선언해주었다.
- Board 를 update 할 때, user 엔티티 자체를 업데이트해주도록 수정하였다.

closes #31 