### PR TITLE
feat: #32 게시글 삭제 기능 구현

### DIFF
--- a/src/main/java/com/sparta/board/controller/BoardController.java
+++ b/src/main/java/com/sparta/board/controller/BoardController.java
@@ -2,8 +2,10 @@ package com.sparta.board.controller;
 
 import com.sparta.board.dto.BoardRequestsDto;
 import com.sparta.board.dto.BoardResponseDto;
+import com.sparta.board.dto.SuccessResponseDto;
 import com.sparta.board.service.BoardService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
@@ -39,9 +41,10 @@ public class BoardController {
         return boardService.updatePost(id, requestsDto, request);
     }
 
-//    @DeleteMapping("/api/post/{id}")
-//    public SuccessResponseDto deletePost(@PathVariable Long id, @RequestBody BoardRequestsDto requestsDto) throws Exception {
-//        return boardService.deletePost(id, requestsDto);
-//    }
+    // 선택된 게시글 삭제
+    @DeleteMapping("/api/post/{id}")
+    public ResponseEntity<SuccessResponseDto> deletePost(@PathVariable Long id, HttpServletRequest request) {
+        return boardService.deletePost(id, request);
+    }
 
 }


### PR DESCRIPTION
- 토큰 값을 확인하기 위해 `updatePost`에서 `HttpServletRequest`를 파라미터에 추가했다.
- 선택한 게시글의 id와 토큰에서 가져온 사용자 정보가 일치하는 게시물이면 삭제한다.

closes #32 