### PR TITLE
feat: #43 User 엔티티 연관관계 매핑 수정

### DIFF
--- a/src/main/java/com/sparta/board/entity/User.java
+++ b/src/main/java/com/sparta/board/entity/User.java
@@ -1,10 +1,11 @@
 package com.sparta.board.entity;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Builder
@@ -22,8 +23,5 @@ public class User {
 
     @Column(nullable = false)
     private String password;
-
-    @OneToMany(mappedBy = "user")
-    List<Board> posts = new ArrayList<>();
 
 }


### PR DESCRIPTION
`User`에서 `Board`를 직접 참조하는 일이 없으므로 `@OneToMany`로 매핑되었던 해당 연관관계를 지웠다.

closes #43 