### PR TITLE
feat: #55 댓글 수정 기능 구현

### DIFF
--- a/src/main/java/com/sparta/board/controller/CommentController.java
+++ b/src/main/java/com/sparta/board/controller/CommentController.java
@@ -16,8 +16,15 @@ public class CommentController {
     private final CommentService commentService;
 
     // 댓글 작성
-    @PostMapping("/comment/{id}")
+    @PostMapping("/comment/{id}")   // 여기서 ID는 게시글의 id
     public ResponseEntity<Object> createComment(@PathVariable Long id, @RequestBody CommentRequestDto requestDto, HttpServletRequest request) {
         return commentService.createComment(id, requestDto, request);
     }
+
+    // 댓글 수정
+    @PutMapping("/comment/{id}")    // 여기서 ID는 댓글의 id
+    public ResponseEntity<Object> updateComment(@PathVariable Long id, @RequestBody CommentRequestDto requestDto, HttpServletRequest request) {
+        return commentService.updateComment(id, requestDto, request);
+    }
+
 }

--- a/src/main/java/com/sparta/board/entity/Comment.java
+++ b/src/main/java/com/sparta/board/entity/Comment.java
@@ -34,4 +34,8 @@ public class Comment extends Timestamped {
         this.user = user;
     }
 
+    public void update(CommentRequestDto requestDto, User user) {
+        this.contents = requestDto.getContents();
+        this.user = user;
+    }
 }

--- a/src/main/java/com/sparta/board/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/board/repository/CommentRepository.java
@@ -1,7 +1,11 @@
 package com.sparta.board.repository;
 
 import com.sparta.board.entity.Comment;
+import com.sparta.board.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    Optional<Comment> findByIdAndUser(Long id, User user);
 }


### PR DESCRIPTION
- 서비스에서 토큰 여부 확인, 수정하려는 회원 정보 DB 확인, 선택한 댓글 정보 DB 확인 작업을 한다.
- 선택한 댓글의 작성자와 수정하려는 회원 정보를 비교하기 위해 리포지토리에 `findByIdAndUser` 함수를 선언했다.
- `findByIdAndUser`로 찾아지는 comment가 있으면 댓글을 수정할 수 있다.
- 찾아지는 comment 가 없다 하더라도 수정하려는 회원 정보의 role이 ADMIN이면 수정할 수 있다.
- 댓글을 수정하기 위해 `Comment`에 `update` 메서드를 만들었다.

closes #55 