### PR TITLE
feat: #58 전체 게시글 목록 댓글 포함 조회

### DIFF
--- a/src/main/java/com/sparta/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/sparta/board/dto/BoardResponseDto.java
@@ -1,11 +1,14 @@
 package com.sparta.board.dto;
 
 import com.sparta.board.entity.Board;
+import com.sparta.board.entity.Comment;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -16,6 +19,7 @@ public class BoardResponseDto {
     private String username;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
+    private List<CommentResponseDto> commentList;
 
     @Builder
     public BoardResponseDto(Board entity) {
@@ -25,6 +29,10 @@ public class BoardResponseDto {
         this.username = entity.getUser().getUsername();
         this.createdAt = entity.getCreatedAt();
         this.modifiedAt = entity.getModifiedAt();
+        this.commentList = entity.getCommentList().stream()
+                .sorted(Comparator.comparing(Comment::getModifiedAt).reversed())
+                .map(CommentResponseDto::new)
+                .toList();
     }
 
 }


### PR DESCRIPTION
댓글 목록도 출력되도록 `BoardResponseDto`에 `List<CommentResponseDto>` 필드를 추가했다. 
댓글 리스트가 작성날짜 기준 내림차순으로 정렬되어야하므로, 생성자에서 commentList 를 정렬 후 저장하도록 처리했다.

closes #58 