### PR TITLE
refactor: @OnDelete 사용하지 않고 회원탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/sparta/board/entity/Board.java
+++ b/src/main/java/com/sparta/board/entity/Board.java
@@ -5,8 +5,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -29,7 +27,6 @@ public class Board extends Timestamped {
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE)

--- a/src/main/java/com/sparta/board/entity/Comment.java
+++ b/src/main/java/com/sparta/board/entity/Comment.java
@@ -5,8 +5,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -25,13 +23,11 @@ public class Comment extends Timestamped {
     private String contents;
 
     @ManyToOne
-    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "board_id", nullable = false)
     private Board board;
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE)

--- a/src/main/java/com/sparta/board/entity/Likes.java
+++ b/src/main/java/com/sparta/board/entity/Likes.java
@@ -4,8 +4,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -20,17 +18,14 @@ public class Likes {
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @ManyToOne
     @JoinColumn(name = "board_id")
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Board board;
 
     @ManyToOne
     @JoinColumn(name = "comment_id")
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Comment comment;
 
     @Builder

--- a/src/main/java/com/sparta/board/repository/BoardRepository.java
+++ b/src/main/java/com/sparta/board/repository/BoardRepository.java
@@ -12,4 +12,6 @@ import java.util.Optional;
 public interface BoardRepository extends JpaRepository<Board, Long> {
     List<Board> findAllByOrderByModifiedAtDesc();
     Optional<Board> findByIdAndUser(Long id, User user);
+
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/sparta/board/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/board/repository/CommentRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Optional<Comment> findByIdAndUser(Long id, User user);
+
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/sparta/board/repository/LikesRepository.java
+++ b/src/main/java/com/sparta/board/repository/LikesRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
 public interface LikesRepository extends JpaRepository<Likes, Long> {
     Optional<Likes> findByBoardAndUser(Board board, User user);
     Optional<Likes> findByCommentAndUser(Comment comment, User user);
+
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/sparta/board/service/UserService.java
+++ b/src/main/java/com/sparta/board/service/UserService.java
@@ -8,6 +8,9 @@ import com.sparta.board.entity.enumSet.ErrorType;
 import com.sparta.board.entity.enumSet.UserRoleEnum;
 import com.sparta.board.exception.RestApiException;
 import com.sparta.board.jwt.JwtUtil;
+import com.sparta.board.repository.BoardRepository;
+import com.sparta.board.repository.CommentRepository;
+import com.sparta.board.repository.LikesRepository;
 import com.sparta.board.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -25,6 +28,9 @@ public class UserService {
 
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
+    private final BoardRepository boardRepository;
+    private final CommentRepository commentRepository;
+    private final LikesRepository likesRepository;
     private final PasswordEncoder passwordEncoder;
 
     // 회원가입
@@ -70,6 +76,7 @@ public class UserService {
     }
 
     // 회원 탈퇴
+    @Transactional
     public ResponseEntity<MessageResponseDto> signout(LoginRequestDto requestDto, User user) {
 
         // 비밀번호 확인
@@ -78,6 +85,9 @@ public class UserService {
             throw new RestApiException(ErrorType.NOT_MATCHING_PASSWORD);
         }
 
+        boardRepository.deleteAllByUser(user);
+        commentRepository.deleteAllByUser(user);
+        likesRepository.deleteAllByUser(user);
         userRepository.delete(user);
 
         return ResponseEntity.ok(MessageResponseDto.of(HttpStatus.OK, "회원탈퇴 완료"));


### PR DESCRIPTION
- 양방향 매핑 @OneToMany에 cascade 옵션은 그대로 두고, 단방향 매핑에 걸었던 @OnDelete를 지웠다.
- UserService 에서 User가 작성한 게시글, 댓글, 좋아요를 차례로 지우고 User를 지우는 방법으로 구현했다.