### PR TITLE
refactor: 양방향 연관관계 편의 메서드 적용

### DIFF
--- a/src/main/java/com/sparta/board/entity/Comment.java
+++ b/src/main/java/com/sparta/board/entity/Comment.java
@@ -54,11 +54,13 @@ public class Comment extends Timestamped {
     }
 
     public static Comment of(CommentRequestDto requestDto, Board board, User user) {
-        return Comment.builder()
+        Comment comment = Comment.builder()
                 .requestDto(requestDto)
                 .board(board)
                 .user(user)
                 .build();
+        board.getCommentList().add(comment);
+        return comment;
     }
 
     public void addChildComment(Comment child) {

--- a/src/main/java/com/sparta/board/entity/Likes.java
+++ b/src/main/java/com/sparta/board/entity/Likes.java
@@ -36,17 +36,21 @@ public class Likes {
     }
 
     public static Likes of(Board board, User user) {
-        return Likes.builder()
+        Likes likes = Likes.builder()
                 .board(board)
                 .user(user)
                 .build();
+        board.getLikesList().add(likes);
+        return likes;
     }
 
     public static Likes of(Comment comment, User user) {
-        return Likes.builder()
+        Likes likes = Likes.builder()
                 .comment(comment)
                 .user(user)
                 .build();
+        comment.getLikesList().add(likes);
+        return likes;
     }
 
 }

--- a/src/main/java/com/sparta/board/service/LikesService.java
+++ b/src/main/java/com/sparta/board/service/LikesService.java
@@ -14,7 +14,6 @@ import com.sparta.board.repository.LikesRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -27,8 +26,7 @@ public class LikesService {
     private final CommentRepository commentRepository;
 
     // 게시글 좋아요 기능
-    @Transactional
-    public ResponseEntity<BoardResponseDto> likePost(Long id, User user) {
+     public ResponseEntity<BoardResponseDto> likePost(Long id, User user) {
         // 선택한 게시글이 DB에 있는지 확인
         Optional<Board> board = boardRepository.findById(id);
         if (board.isEmpty()) {
@@ -49,7 +47,6 @@ public class LikesService {
     }
 
     // 댓글 좋아요 기능
-    @Transactional
     public ResponseEntity<CommentResponseDto> likeComment(Long id, User user) {
         // 선택한 댓글이 DB에 있는지 확인
         Optional<Comment> comment = commentRepository.findById(id);


### PR DESCRIPTION
양방향으로 연관관계 매핑된 경우, 연관관계 주인쪽에서 객체를 만들 때 반대편 객체에도 값을 넣어주도록 편의 메서드를 적용했다.
좋아요 기능에서 @Transactional을 넣는 경우,
Likes.of로 객체를 생성할 때 board의 LikesList에 Like 객체가 들어가고, Likes 객체 생성해서 저장할 때 board의 LikesList에 Like 객체가 또 들어가게 되므로 여기서는 @Transactional을 사용하지 않는다.